### PR TITLE
Can also use data-href on wheel button.

### DIFF
--- a/jquery.wheelmenu.js
+++ b/jquery.wheelmenu.js
@@ -252,8 +252,10 @@
     settings = predefineSpeed(settings);
     
     return this.each(function(){
-      var button = $(this)
-      var el = $($(this).attr("href"));
+      var button, $this, el,
+      $this = $(this);
+      button = $this;
+      el = $($this.attr("href") || $this.attr('data-href'));
       el.addClass("wheel");
       
       button.css("opacity", 0).animate({


### PR DESCRIPTION
The example usecase is when I want to use another element for the wheel button (ex: button element). The quite annoying thing with the limitation of only using "a" element is because of the "jump effect" .

When "a" element is clicked the viewport will jump to the top because it doesn't find any element with id same as the href fragment. And to solve this issue I use button element as the replacement.
