### PR TITLE
Update jquery.wheelmenu.js

### DIFF
--- a/jquery.wheelmenu.js
+++ b/jquery.wheelmenu.js
@@ -130,7 +130,7 @@
     
     
 	  el.show().css({
-        position: 'absolute',
+        'position': 'fixed',
         'z-index': '5',
         'padding': '30px' // add safe zone for mouseover
     }).centerAround(button); 


### PR DESCRIPTION
line 133, if the position is 'absolute' , when click the button ， the even click will be wrong
